### PR TITLE
Make example of `Sparkline#format` pasteable

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ Let's further suppose you use a gem that adds a `#color` method to `String`
 for ANSI coloring, like
 [Term::ANSIColor](https://github.com/flori/term-ansicolor).
 
+    require 'term/ansicolor'
+    class String
+      include Term::ANSIColor
+    end
+
     Sparkr.sparkline(list) do |tick, count, index|
       if index == 0
         tick.color(:red)

--- a/lib/sparkr/sparkline.rb
+++ b/lib/sparkr/sparkline.rb
@@ -32,6 +32,11 @@ module Sparkr
     # suppose you use a gem that adds a #color method to String
     # for ANSI coloring.
     #
+    #   require 'term/ansicolor'
+    #   class String
+    #     include Term::ANSIColor
+    #   end
+    #
     #   list = [open_issue_count, closed_issue_count]
     #   sparkline = Sparkr::Sparkline.new(list)
     #   sparkline.format do |tick, count, index|


### PR DESCRIPTION
Show exactly how to use `Term::ANSIColor` this example.
